### PR TITLE
Add macOS build workflow

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -7,20 +7,19 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          target: x86_64-apple-darwin
           override: true
       - name: Build release binary
-        run: cargo build --release --target x86_64-apple-darwin
+        run: cargo build --release
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: n8n-workflow-sync-macos
-          path: target/x86_64-apple-darwin/release/n8n-workflow-sync
+          path: target/release/n8n-workflow-sync
 


### PR DESCRIPTION
## Summary
- build release binary for macOS on every push and PR
- use `actions/upload-artifact@v4`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6858197ece488330a2e131c4dc078072