### PR TITLE
Add macOS release artifact

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,31 @@
+name: Build macOS binary
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Build release binary
+        run: cargo build --release
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: n8n-workflow-sync-macos
+          path: target/release/n8n-workflow-sync
+      - name: Create GitHub release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: target/release/n8n-workflow-sync
+


### PR DESCRIPTION
## Summary
- release macOS builds when pushing tags so users can download binaries

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6858197ece488330a2e131c4dc078072