### PR TITLE
Add release upload to GH workflow

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -3,7 +3,12 @@ name: Build macOS binary
 on:
   push:
     branches: [main]
+    tags:
+      - 'v*'
   pull_request:
+
+permissions:
+  contents: write
 
 jobs:
   build:
@@ -22,4 +27,11 @@ jobs:
         with:
           name: n8n-workflow-sync-macos
           path: target/release/n8n-workflow-sync
+      - name: Upload release asset
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: target/release/n8n-workflow-sync
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- upload macOS build as a release asset
- trigger build workflow on tags starting with `v`
- grant contents write permission for creating releases

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68582af71b348330af2e0cf06269f0de