### PR TITLE
Add node version fetch and docs

### DIFF
--- a/.cursor/rules/node-versions.mdc
+++ b/.cursor/rules/node-versions.mdc
@@ -1,0 +1,3 @@
+# Node versions metadata
+
+When generating or updating n8n workflows via JSON, use the `node-versions.json` file located alongside the workflow JSON to determine the latest `typeVersion` for each node. This file is generated automatically by `n8n-workflow-sync` and should not be committed to Git.

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+**/node-versions.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,6 +1028,7 @@ dependencies = [
  "confy",
  "dialoguer",
  "git2",
+ "regex",
  "reqwest",
  "self_update",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ tracing     = "0.1"
 url         = "2"
 dialoguer   = "0.11"
 self_update = "0.42"
+regex       = "1"
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,12 @@
 pub mod api;
 pub mod config;
+pub mod nodes;
 
 #[cfg(test)]
 mod tests {
+    use url::Url;
     use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
-    use url::Url;
 
     #[tokio::test]
     async fn list_workflows() {
@@ -39,12 +40,10 @@ mod tests {
         Mock::given(method("POST"))
             .and(path("/api/v1/workflows"))
             .and(header("X-N8N-API-KEY", "test-key"))
-            .respond_with(
-                ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                    "id": "2",
-                    "name": "New"
-                })),
-            )
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "2",
+                "name": "New"
+            })))
             .mount(&server)
             .await;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use clap::{Parser, Subcommand};
 use dialoguer::Confirm;
 use git2::{Repository, Signature};
-use n8n_workflow_sync::{api, config};
+use n8n_workflow_sync::{api, config, nodes};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -162,6 +162,10 @@ async fn main() -> anyhow::Result<()> {
             fs::write(&json_path, data)
                 .with_context(|| format!("Failed to write workflow to {}", json_path.display()))?;
 
+            nodes::save_node_versions(&dir)
+                .await
+                .with_context(|| "Failed to fetch node versions")?;
+
             // Initialize git repository
             let repo = Repository::init(&dir).with_context(|| {
                 format!("Failed to initialize git repository in {}", dir.display())
@@ -230,6 +234,10 @@ async fn main() -> anyhow::Result<()> {
             let data = serde_json::to_vec_pretty(&wf_json)?;
             fs::write(&json_path, data)
                 .with_context(|| format!("Failed to write to {}", json_path.display()))?;
+
+            nodes::save_node_versions(&dir)
+                .await
+                .with_context(|| "Failed to fetch node versions")?;
 
             // Initialise git repo if none exists
             let repo = match Repository::open(&dir) {

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -1,0 +1,76 @@
+use anyhow::Result;
+use regex::Regex;
+use reqwest::Client;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+#[derive(Deserialize)]
+struct Tree {
+    tree: Vec<Entry>,
+}
+
+#[derive(Deserialize)]
+struct Entry {
+    path: String,
+    #[serde(rename = "type")]
+    entry_type: String,
+}
+
+/// Fetch the latest node versions from the n8n repository
+pub async fn fetch_node_versions() -> Result<HashMap<String, u32>> {
+    let client = Client::new();
+    let tree_url = "https://api.github.com/repos/n8n-io/n8n/git/trees/master?recursive=1";
+    let tree: Tree = client
+        .get(tree_url)
+        .header("User-Agent", "n8n-workflow-sync")
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+
+    let file_re = Regex::new(r"^packages/nodes-base/nodes/([^/]+)/.*\.node.[jt]s$")?;
+    let version_re = Regex::new(r"version:\s*(\d+)")?;
+    let mut map: HashMap<String, u32> = HashMap::new();
+
+    for entry in tree.tree {
+        if entry.entry_type == "blob" {
+            if let Some(caps) = file_re.captures(&entry.path) {
+                let node_name = caps.get(1).unwrap().as_str().to_string();
+                let raw_url = format!(
+                    "https://raw.githubusercontent.com/n8n-io/n8n/master/{}",
+                    entry.path
+                );
+                let text = client
+                    .get(&raw_url)
+                    .header("User-Agent", "n8n-workflow-sync")
+                    .send()
+                    .await?
+                    .error_for_status()?
+                    .text()
+                    .await?;
+
+                if let Some(v_caps) = version_re.captures(&text) {
+                    if let Ok(v) = v_caps[1].parse::<u32>() {
+                        map.entry(node_name)
+                            .and_modify(|e| *e = (*e).max(v))
+                            .or_insert(v);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(map)
+}
+
+/// Fetch node versions and save them as `node-versions.json` in the given directory
+pub async fn save_node_versions<P: AsRef<Path>>(dir: P) -> Result<()> {
+    let versions = fetch_node_versions().await?;
+    let path = dir.as_ref().join("node-versions.json");
+    let data = serde_json::to_vec_pretty(&versions)?;
+    fs::write(path, data)?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add regex crate for parsing versions
- add node version fetching module and calls
- ignore generated node version metadata
- document node metadata for agents

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68593fe8a188833090db4197382743b2