### PR TITLE
Add CI badge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Run tests
+        run: cargo test --locked

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # n8n-workflow-sync
 
+[![Tests](https://github.com/dunctk/n8n-workflow-sync/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/dunctk/n8n-workflow-sync/actions/workflows/test.yml)
+
 `n8n-workflow-sync` is a command line tool to list and create workflows on an n8n instance. It aims to let you version control workflows locally and sync them via the n8n REST API.
 
 ## Installation


### PR DESCRIPTION
## Summary
- run tests in CI via a new workflow
- show workflow badge in the README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685d3aed15e88330ab4f5fcb31460ec2