### PR TITLE
Add code coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,27 @@
+name: Coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin
+      - name: Generate coverage
+        run: cargo tarpaulin --out Xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true
+          files: cobertura.xml
+          verbose: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # n8n-workflow-sync
 
 [![Tests](https://github.com/dunctk/n8n-workflow-sync/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/dunctk/n8n-workflow-sync/actions/workflows/test.yml)
+[![Coverage](https://codecov.io/gh/dunctk/n8n-workflow-sync/branch/main/graph/badge.svg)](https://codecov.io/gh/dunctk/n8n-workflow-sync)
 
 `n8n-workflow-sync` is a command line tool to list and create workflows on an n8n instance. It aims to let you version control workflows locally and sync them via the n8n REST API.
 


### PR DESCRIPTION
## Summary
- track code coverage with Tarpaulin
- show Codecov badge in README

## Testing
- `cargo test --locked`


------
https://chatgpt.com/codex/tasks/task_e_685d741093f88330b7a8add5e0926962