### PR TITLE
Ensure Codecov token is passed

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,3 +25,4 @@ jobs:
           fail_ci_if_error: true
           files: cobertura.xml
           verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- configure CI to pass CODECOV_TOKEN from GitHub secrets

## Testing
- `cargo test --locked`

------
https://chatgpt.com/codex/tasks/task_e_685da57a6d588330ad76c728f39100d8